### PR TITLE
Refresh markerplace README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 A :octocat: GitHub Action to setup [BATS testing framework][bats].
 
-> **:warning: Note:** [GitHub Actions](https://github.com/features/actions) are currently only available in public beta, you have to [apply](https://github.com/features/actions/signup/) to gain access.
-
 ## Usage 🚀
 
 A sample workflow to run tests using [BATS][] (`.github/workflows/ci.yml`):
@@ -20,7 +18,7 @@ jobs:
     steps:
 
       - name: Setup BATS
-        uses: mig4/setup-bats@master
+        uses: mig4/setup-bats@v1
         with:
           bats-version: 1.1.0
 


### PR DESCRIPTION
Since marketplace shows README from the master branch, change it to
suggest using the latest release. Using master directly is not supported
and in fact doesn't work in current form.

Also, Actions are now out of beta so remove the warning.

Towards #5