### PR TITLE
Normalise CI environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Show info
+        run: npm version
+
       - name: Install deps
         run: npm install
 
@@ -32,6 +35,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Show info
+        run: npm version
 
       - name: Setup BATS
         uses: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,6 @@ jobs:
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-
       - name: Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
Currently the _build_ and _test_ jobs appear to run in different environments. And both of those seem to be different from my local dev environment. This isn't good.

Also print env and project info to help debug environmental issues.
