### PR TITLE
Updating node runtime from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: 'The BATS version to setup. Example: 1.0.0 or master, default: 1.2.1'
     default: '1.2.1'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
As reported in  #368, `node12` has been deprecated from Github. This PR bumps it to 16.